### PR TITLE
Clarifying standard SKU requirement of public ip

### DIFF
--- a/articles/virtual-network/routing-preference-overview.md
+++ b/articles/virtual-network/routing-preference-overview.md
@@ -87,7 +87,7 @@ Routing Preference support is available in the following regions for services su
 Routing Preference support for storage account is available in the following Azure regions - North Central US, West Central US, South Central US, East US, West US,  North Europe, France South, Germany West Central, Switzerland West, South East Asia, Japan East, and Japan West.
 ## Limitations
 
-* Routing preference is only compatible with standard SKU of public IP address. Basic SKU of public IP address is not supported.
+* Routing preference is only compatible with standard SKU of zone-redundant public IP address. Basic SKU of public IP address is not supported.
 * Routing preference currently supports only IPv4 public IP addresses. IPv6 public IP addresses are not supported.
 * Virtual machines with multiple NICs can have only one type of routing preference.
 


### PR DESCRIPTION
Routing preference supports only zone-redundant public IP. Creating a public IP in a particular Availability Zone(available through the Azure Portal) to use with Routing Preference will result in this error:
  
{
    "status": "Failed",
    "error": {
        "code": "PublicIPAddressWithOneZoneDoesNotSupportRoutingPreference",
        "message": "A zonal PublicIPAddress /subscriptions/efcdce030-4761-56a90-a955-4554b1df2f003e/resourceGroups/myrg2/providers/Microsoft.Network/publicIPAddresses/RPpupip cannot support for routing preference feature",
        "details": []
    }
}